### PR TITLE
Fix path handling and add e2e image extract test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ replace (
 
 require (
 	github.com/frankban/quicktest v1.12.1 // indirect
-	github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9
+	github.com/google/go-containerregistry v0.7.0
 	github.com/klauspost/compress v1.13.6
 	github.com/pierrec/lz4 v2.6.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,7 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17-0.20210324224401-5516f17a5958/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
-github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+github.com/Microsoft/go-winio v0.5.1/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7-0.20190325164909-8abdbb8205e4/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
@@ -154,8 +154,11 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/container-storage-interface/spec v1.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
@@ -219,8 +222,8 @@ github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJ
 github.com/containerd/nri v0.0.0-20201007170849-eb1350a75164/go.mod h1:+2wGSDGFYfE5+So4M5syatU0N0f0LbWpuqyMi4/BE8c=
 github.com/containerd/nri v0.0.0-20210316161719-dbaa18c31c14/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
-github.com/containerd/stargz-snapshotter/estargz v0.9.0 h1:PkB6BSTfOKX23erT2GkoUKkJEcXfNcyKskIViK770v8=
-github.com/containerd/stargz-snapshotter/estargz v0.9.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
+github.com/containerd/stargz-snapshotter/estargz v0.10.0 h1:glqzafvxBBAMo+x2w2sdDjUDZeTqqLJmqZPY05qehCU=
+github.com/containerd/stargz-snapshotter/estargz v0.10.0/go.mod h1:aE5PCyhFMwR8sbrErO5eM2GcvkyXTTJremG883D4qF0=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=
@@ -282,8 +285,8 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/cli v20.10.9+incompatible h1:OJ7YkwQA+k2Oi51lmCojpjiygKpi76P7bg91b2eJxYU=
-github.com/docker/cli v20.10.9+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
+github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -461,8 +464,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9 h1:m5Yu3eJF1gVvzA51M9Ll2TZH+fi8P38bBVDL2jdQzoU=
-github.com/google/go-containerregistry v0.6.1-0.20211111182346-7a6ee45528a9/go.mod h1:VGc0QpDDhK6zwYGlQb3s0LDGbTCGMFiifm0UgG9v1oQ=
+github.com/google/go-containerregistry v0.7.0 h1:u0onUUOcyoCDHEiJoyR1R1gx5er1+r06V5DBhUU5ndk=
+github.com/google/go-containerregistry v0.7.0/go.mod h1:2zaoelrL0d08gGbpdP3LqyUuBmhWbpD6IOe2s9nLS2k=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1044,8 +1047,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211005215030-d2e5035098b3 h1:G64nFNerDErBd2KdvHvIn3Ee6ccUQBTfhDZEO0DccfU=
-golang.org/x/net v0.0.0-20211005215030-d2e5035098b3/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211111160137-58aab5ef257a h1:c83jeVQW0KGKNaKBRfelNYNHaev+qawl9yaA825s8XE=
+golang.org/x/net v0.0.0-20211111160137-58aab5ef257a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1062,8 +1065,8 @@ golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 h1:B333XXssMuKQeBwiNODx4TupZy7bf4sxFZnN2ZOcvUE=
-golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1170,8 +1173,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210908233432-aa78b53d3365/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08 h1:WecRHqgE09JBkh/584XIE6PMz5KKE/vER4izNUi30AQ=
+golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -1367,7 +1370,7 @@ google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71/go.mod h1:eFjDcFEc
 google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210903162649-d08c68adba83/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
 google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20211111162719-482062a4217b/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -1397,7 +1400,7 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
+google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -4,126 +4,178 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sirupsen/logrus"
 )
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+}
+
+func TestFindPathFromExtract(t *testing.T) {
+	tempdir := t.TempDir()
+	testImageRef := "docker.io/rancher/rke2-runtime:v1.22.4-rke2r1"
+	ref, err := name.ParseReference(testImageRef)
+	if err != nil {
+		t.Fatalf("Failed to parse image reference: %v", err)
+	}
+
+	testOperatingSystems := map[string]string{
+		"linux":   "containerd",
+		"windows": "containerd.exe",
+	}
+
+	// https://github.com/google/go-containerregistry/commit/f9a1886f3df0e2b00d6c62715114fe1093ab1ad7
+	// changed go-containerregistry behavior; tar paths are now platform-specific and will have forward
+	// slashes on Linux and backslashes on Windows.
+	for operatingSystem, pauseBin := range testOperatingSystems {
+		image, err := remote.Image(ref, remote.WithPlatform(v1.Platform{Architecture: "amd64", OS: operatingSystem}))
+		if err != nil {
+			t.Fatalf("Failed to pull remote image: %v", err)
+		}
+
+		extractMap := map[string]string{
+			"/bin":    filepath.Join(tempdir, "bin"),
+			"/charts": filepath.Join(tempdir, "charts"),
+		}
+
+		t.Logf("Testing ExtractDirs with map %#v for %s", extractMap, operatingSystem)
+		if err := ExtractDirs(image, extractMap); err != nil {
+			t.Errorf("Failed to extract containerd binary for %s: %v", operatingSystem, err)
+			continue
+		}
+
+		i, err := os.Stat(filepath.Join(tempdir, "bin", pauseBin))
+		if err != nil {
+			t.Errorf("containerd binary for %s not found: %v", operatingSystem, err)
+			continue
+		}
+
+		t.Logf("containerd binary for %s extracted successfully: %s", operatingSystem, i.Name())
+	}
+}
 
 func TestFindPath(t *testing.T) {
 	type mss map[string]string
-	type testPath struct{
-		in    string
-		out   string
-		err   error
+	type testPath struct {
+		in  string
+		out string
+		err error
 	}
 	temp := os.TempDir()
-	findPathTests := []struct{
+	findPathTests := []struct {
 		dirs  mss
 		paths []testPath
 	}{
 		{
 			// test a simple root directory mapping with various valid and invalid paths
-			dirs:  mss{"/": temp},
+			dirs: mss{"/": temp},
 			paths: []testPath{
 				{
-					in: "/test.txt",
+					in:  "/test.txt",
 					out: filepath.Join(temp, "test.txt"),
 					err: nil,
-				},{
-					in: "///test.txt",
+				}, {
+					in:  "///test.txt",
 					out: filepath.Join(temp, "test.txt"),
 					err: nil,
-				},{
-					in: "/etc/../test.txt",
+				}, {
+					in:  "/etc/../test.txt",
 					out: filepath.Join(temp, "test.txt"),
 					err: nil,
-				},{
-					in: "test.txt",
+				}, {
+					in:  "test.txt",
 					out: filepath.Join(temp, "test.txt"),
 					err: nil,
-				},{
-					in: "/etc/hosts",
+				}, {
+					in:  "/etc/hosts",
 					out: filepath.Join(temp, "etc", "hosts"),
 					err: nil,
-				},{
-					in: "/var/lib/rancher",
+				}, {
+					in:  "/var/lib/rancher",
 					out: filepath.Join(temp, "var", "lib", "rancher"),
 					err: nil,
-				},{
-					in: "../../etc/passwd",
+				}, {
+					in:  "../../etc/passwd",
 					out: "",
 					err: ErrIllegalPath,
 				},
 			},
-		},{
+		}, {
 			// test no mapping at all
 			dirs: mss{},
 			paths: []testPath{
 				{
-					in: "/text.txt",
+					in:  "/text.txt",
 					out: "",
 					err: nil,
 				},
 			},
-		},{
+		}, {
 			// test mapping various nested paths
 			dirs: mss{
 				"/Files/bin": filepath.Join(temp, "Files-bin"),
-				"/Files": filepath.Join(temp, "Files"),
-				"/etc": filepath.Join(temp, "etc"),
-				},
+				"/Files":     filepath.Join(temp, "Files"),
+				"/etc":       filepath.Join(temp, "etc"),
+			},
 			paths: []testPath{
 				{
-					in: "Files/bin",
+					in:  "Files/bin",
 					out: filepath.Join(temp, "Files-bin"),
 					err: nil,
-				},{
-					in: "Files/bin/test.txt",
+				}, {
+					in:  "Files/bin/test.txt",
 					out: filepath.Join(temp, "Files-bin", "test.txt"),
 					err: nil,
-				},{
-					in: "Files/bin/aux",
+				}, {
+					in:  "Files/bin/aux",
 					out: filepath.Join(temp, "Files-bin", "aux"),
 					err: nil,
-				},{
-					in: "Files/bin/aux/mount",
+				}, {
+					in:  "Files/bin/aux/mount",
 					out: filepath.Join(temp, "Files-bin", "aux", "mount"),
 					err: nil,
-				},{
-					in: "Files",
+				}, {
+					in:  "Files",
 					out: filepath.Join(temp, "Files"),
 					err: nil,
-				},{
-					in: "Files/test.txt",
+				}, {
+					in:  "Files/test.txt",
 					out: filepath.Join(temp, "Files", "test.txt"),
 					err: nil,
-				},{
-					in: "Files/opt",
+				}, {
+					in:  "Files/opt",
 					out: filepath.Join(temp, "Files", "opt"),
 					err: nil,
-				},{
-					in: "Files/opt/other.txt",
+				}, {
+					in:  "Files/opt/other.txt",
 					out: filepath.Join(temp, "Files", "opt", "other.txt"),
 					err: nil,
-				},{
-					in: "etc",
+				}, {
+					in:  "etc",
 					out: filepath.Join(temp, "etc"),
 					err: nil,
-				},{
-					in: "etc/hosts",
+				}, {
+					in:  "etc/hosts",
 					out: filepath.Join(temp, "etc", "hosts"),
 					err: nil,
-				},{
-					in: "etc/shadow/passwd",
+				}, {
+					in:  "etc/shadow/passwd",
 					out: filepath.Join(temp, "etc", "shadow", "passwd"),
 					err: nil,
-				},{
-					in: "sbin",
+				}, {
+					in:  "sbin",
 					out: "",
 					err: nil,
-				},{
-					in: "sbin/ip",
+				}, {
+					in:  "sbin/ip",
 					out: "",
 					err: nil,
-				},{
-					in: "Files/bin/../../../../etc/passwd",
+				}, {
+					in:  "Files/bin/../../../../etc/passwd",
 					out: "",
 					err: ErrIllegalPath,
 				},
@@ -134,13 +186,20 @@ func TestFindPath(t *testing.T) {
 	for _, test := range findPathTests {
 		t.Logf("Testing paths with dirs %#v", test.dirs)
 		for _, testPath := range test.paths {
-			destination, err := findPath(test.dirs, testPath.in)
-			t.Logf("Got mapped path %q, err %v for image path %q", destination, err, testPath.in)
+			dirs, err := cleanExtractDirs(test.dirs)
+			if err != nil {
+				t.Errorf("Failed to clean extracted dirs: %v", err)
+				continue
+			}
+			// as of recent go-containerruntime versions, tar file paths are pre-processed with filepath.Clean
+			in := filepath.Clean(testPath.in)
+			destination, err := findPath(dirs, in)
+			t.Logf("Got mapped path %q, err %v for image path %q", destination, err, in)
 			if destination != testPath.out {
-				t.Errorf("Expected path %q but got path %q for image path %q", testPath.out, destination, testPath.in)
+				t.Errorf("Expected path %q but got path %q for image path %q", testPath.out, destination, in)
 			}
 			if err != testPath.err {
-				t.Errorf("Expected error %v but got error %v for image path %q", testPath.err, err, testPath.in)
+				t.Errorf("Expected error %v but got error %v for image path %q", testPath.err, err, in)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes a regression caused by updating go-containerregistry, which causes
tar entry paths to be normalized to use os-specific path separators:
https://github.com/google/go-containerregistry/commit/f9a1886f3

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>

Tested locally on Windows, both via `go test` and pulled through into RKE2.

Windows test output:
```console
?   	github.com/rancher/wharfie/pkg/credentialprovider/plugin	[no test files]
=== RUN   TestFindPathFromExtract
    extract_test.go:45: Testing ExtractDirs with map map[string]string{"/bin":"C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin", "/charts":"C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts"} for linux
time="2021-12-21T23:46:49-08:00" level=info msg="Creating directory C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin"
time="2021-12-21T23:46:49-08:00" level=info msg="Extracting file bin\\containerd to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd"
time="2021-12-21T23:46:49-08:00" level=info msg="Extracting file bin\\containerd-shim to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd-shim"
time="2021-12-21T23:46:50-08:00" level=info msg="Extracting file bin\\containerd-shim-runc-v1 to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd-shim-runc-v1"
time="2021-12-21T23:46:50-08:00" level=info msg="Extracting file bin\\containerd-shim-runc-v2 to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd-shim-runc-v2"
time="2021-12-21T23:46:50-08:00" level=info msg="Extracting file bin\\crictl to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\crictl"
time="2021-12-21T23:46:51-08:00" level=info msg="Extracting file bin\\ctr to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\ctr"
time="2021-12-21T23:46:51-08:00" level=info msg="Extracting file bin\\kubectl to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\kubectl"
time="2021-12-21T23:46:52-08:00" level=info msg="Extracting file bin\\kubelet to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\kubelet"
time="2021-12-21T23:46:53-08:00" level=info msg="Extracting file bin\\runc to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\runc"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file bin\\socat to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\socat"
time="2021-12-21T23:46:54-08:00" level=info msg="Creating directory C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\harvester-cloud-provider.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\harvester-cloud-provider.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\harvester-csi-driver.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\harvester-csi-driver.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rancher-vsphere-cpi.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rancher-vsphere-cpi.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rancher-vsphere-csi.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rancher-vsphere-csi.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-calico-crd.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-calico-crd.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-calico.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-calico.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-canal.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-canal.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-cilium.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-cilium.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-coredns.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-coredns.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-ingress-nginx.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-ingress-nginx.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-metrics-server.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-metrics-server.yaml"
time="2021-12-21T23:46:54-08:00" level=info msg="Extracting file charts\\rke2-multus.yaml to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts\\rke2-multus.yaml"
    extract_test.go:57: containerd binary for linux extracted successfully: containerd
    extract_test.go:45: Testing ExtractDirs with map map[string]string{"/bin":"C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin", "/charts":"C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\charts"} for windows
time="2021-12-21T23:46:55-08:00" level=info msg="Creating directory C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin"
time="2021-12-21T23:46:55-08:00" level=info msg="Extracting file bin\\calico-ipam.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\calico-ipam.exe"
time="2021-12-21T23:46:56-08:00" level=info msg="Extracting file bin\\calico-node.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\calico-node.exe"
time="2021-12-21T23:46:57-08:00" level=info msg="Extracting file bin\\calico.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\calico.exe"
time="2021-12-21T23:46:57-08:00" level=info msg="Extracting file bin\\containerd-shim-runhcs-v1.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd-shim-runhcs-v1.exe"
time="2021-12-21T23:46:58-08:00" level=info msg="Extracting file bin\\containerd.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\containerd.exe"
time="2021-12-21T23:46:58-08:00" level=info msg="Extracting file bin\\crictl.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\crictl.exe"
time="2021-12-21T23:46:59-08:00" level=info msg="Extracting file bin\\ctr.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\ctr.exe"
time="2021-12-21T23:46:59-08:00" level=info msg="Extracting file bin\\hns.psm1 to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\hns.psm1"
time="2021-12-21T23:46:59-08:00" level=info msg="Extracting file bin\\host-local.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\host-local.exe"
time="2021-12-21T23:46:59-08:00" level=info msg="Extracting file bin\\kube-proxy.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\kube-proxy.exe"
time="2021-12-21T23:47:00-08:00" level=info msg="Extracting file bin\\kubectl.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\kubectl.exe"
time="2021-12-21T23:47:01-08:00" level=info msg="Extracting file bin\\kubelet.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\kubelet.exe"
time="2021-12-21T23:47:02-08:00" level=info msg="Extracting file bin\\win-overlay.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\win-overlay.exe"
time="2021-12-21T23:47:03-08:00" level=info msg="Extracting file bin\\wins.exe to C:\\Users\\brandond\\AppData\\Local\\Temp\\TestFindPathFromExtract2648320399\\001\\bin\\wins.exe"
    extract_test.go:57: containerd binary for windows extracted successfully: containerd.exe
--- PASS: TestFindPathFromExtract (15.42s)
=== RUN   TestFindPath
    extract_test.go:187: Testing paths with dirs extract.mss{"/":"C:\\Users\\brandond\\AppData\\Local\\Temp"}
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\test.txt", err <nil> for image path "\\test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\test.txt", err <nil> for image path "\\test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\test.txt", err <nil> for image path "\\test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\test.txt", err <nil> for image path "test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\etc\\hosts", err <nil> for image path "\\etc\\hosts"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\var\\lib\\rancher", err <nil> for image path "\\var\\lib\\rancher"
    extract_test.go:197: Got mapped path "", err illegal path for image path "..\\..\\etc\\passwd"
    extract_test.go:187: Testing paths with dirs extract.mss{}
    extract_test.go:197: Got mapped path "", err <nil> for image path "\\text.txt"
    extract_test.go:187: Testing paths with dirs extract.mss{"/Files":"C:\\Users\\brandond\\AppData\\Local\\Temp\\Files", "/Files/bin":"C:\\Users\\brandond\\AppData\\Local\\Temp\\Files-bin", "/etc":"C:\\Users\\brandond\\AppData\\Local\\Temp\\etc"}
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files-bin", err <nil> for image path "Files\\bin"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files-bin\\test.txt", err <nil> for image path "Files\\bin\\test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files-bin\\aux", err <nil> for image path "Files\\bin\\aux"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files-bin\\aux\\mount", err <nil> for image path "Files\\bin\\aux\\mount"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files", err <nil> for image path "Files"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files\\test.txt", err <nil> for image path "Files\\test.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files\\opt", err <nil> for image path "Files\\opt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\Files\\opt\\other.txt", err <nil> for image path "Files\\opt\\other.txt"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\etc", err <nil> for image path "etc"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\etc\\hosts", err <nil> for image path "etc\\hosts"
    extract_test.go:197: Got mapped path "C:\\Users\\brandond\\AppData\\Local\\Temp\\etc\\shadow\\passwd", err <nil> for image path "etc\\shadow\\passwd"
    extract_test.go:197: Got mapped path "", err <nil> for image path "sbin"
    extract_test.go:197: Got mapped path "", err <nil> for image path "sbin\\ip"
    extract_test.go:197: Got mapped path "", err illegal path for image path "..\\..\\etc\\passwd"
--- PASS: TestFindPath (0.00s)
PASS
ok  	github.com/rancher/wharfie/pkg/extract	(cached)
=== RUN   TestRewrite
time="2021-12-21T23:46:48-08:00" level=warning msg="Failed to compile rewrite `(.*` for index.docker.io"
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for registry.local/test as registry.local/test:latest - got registry.local/test:latest
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/docker/library/busybox:latest
    registries_test.go:156: OK  rewrite for registry.local/test as registry.local/test:latest - got registry.local/test:latest
    registries_test.go:156: OK  rewrite for busybox@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 as index.docker.io/library/busybox@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3 - got index.docker.io/docker/library/busybox@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for registry.local/test as registry.local/test:latest - got registry.local/localimages/test:latest
    registries_test.go:156: OK  rewrite for rancher/rancher:v2.5.9 as index.docker.io/rancher/rancher:v2.5.9 - got index.docker.io/rancher/prod/rancher:v2.5.9
    registries_test.go:156: OK  rewrite for longhornio/longhorn-engine:v1.1.1 as index.docker.io/longhornio/longhorn-engine:v1.1.1 - got index.docker.io/longhornio/staging/longhorn-engine:v1.1.1
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for registry.local/test as registry.local/test:latest - got registry.local/test:latest
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox:latest
    registries_test.go:156: OK  rewrite for k8s.gcr.io/pause:3.2 as k8s.gcr.io/pause:3.2 - got k8s.gcr.io/k8s.gcr.io/pause:3.2
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/mirrored-library/busybox:latest
    registries_test.go:156: OK  rewrite for busybox as index.docker.io/library/busybox:latest - got index.docker.io/library/busybox/docker:latest
    registries_test.go:156: OK  rewrite for registry.local/team1/images/test as registry.local/team1/images/test:latest - got registry.local/team1-images-test:latest
--- PASS: TestRewrite (0.00s)
=== RUN   TestEndpoints
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm(nil)
        configs: registries.msr(nil)
    registries_test.go:292: Testing image registry.example.com/busybox with:
        mirrors: registries.msm(nil)
        configs: registries.msr(nil)
    registries_test.go:292: Testing image registry.example.com/busybox with:
        mirrors: registries.msm{"registry.example.com":registries.Mirror{Endpoints:[]string{"http://registry.example.com:5000/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"registry.example.com":registries.Mirror{Endpoints:[]string{"https://registry.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"https://docker.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"https://docker1.example.com/v2", "https://docker2.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"*":registries.Mirror{Endpoints:[]string{"https://registry.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"*":registries.Mirror{Endpoints:[]string{"https://registry.example.com/v2"}, Rewrites:map[string]string(nil)}, "docker.io":registries.Mirror{Endpoints:[]string{"https://docker.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"https://docker1.example.com/v2", "https://user:bad{@docker2.example.com"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
time="2021-12-21T23:46:48-08:00" level=warning msg="Ignoring invalid endpoint URL for registry index.docker.io: parse \"https://user:bad{@docker2.example.com\": net/url: invalid userinfo"
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"https://docker1.example.com/v2", "docker2.example.com/v2", "/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr(nil)
time="2021-12-21T23:46:48-08:00" level=warning msg="Ignoring relative endpoint URL for registry index.docker.io: \"docker2.example.com/v2\""
time="2021-12-21T23:46:48-08:00" level=warning msg="Ignoring relative endpoint URL for registry index.docker.io: \"/v2\""
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm(nil)
        configs: registries.msr{"docker.io":registries.RegistryConfig{Auth:(*registries.AuthConfig)(0xc00004af00), TLS:(*registries.TLSConfig)(nil)}}
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"https://docker1.example.com/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr{"docker1.example.com":registries.RegistryConfig{Auth:(*registries.AuthConfig)(0xc00004af40), TLS:(*registries.TLSConfig)(nil)}}
    registries_test.go:292: Testing image busybox with:
        mirrors: registries.msm{"docker.io":registries.Mirror{Endpoints:[]string{"http://docker1.example.com:5000/v2"}, Rewrites:map[string]string(nil)}}
        configs: registries.msr{"docker1.example.com:5000":registries.RegistryConfig{Auth:(*registries.AuthConfig)(0xc00004af80), TLS:(*registries.TLSConfig)(nil)}}
--- PASS: TestEndpoints (0.00s)
PASS
ok  	github.com/rancher/wharfie/pkg/registries	(cached)
?   	github.com/rancher/wharfie/pkg/tarfile	[no test files]
?   	github.com/rancher/wharfie/pkg/util	[no test files]

```