### PR TITLE
Fix missing tag causing build failure

### DIFF
--- a/scripts/build-plugins
+++ b/scripts/build-plugins
@@ -16,6 +16,6 @@ cd cloud-provider-aws
 CGO_ENABLED=0 go build -v -tags="$TAGS" -ldflags="$LDFLAGS" -o=${BASE}/bin/plugins/ecr-credential-provider cmd/ecr-credential-provider/*.go
 
 cd ${BASE}/build/plugins
-git clone -b v0.21.0 --depth 1 https://github.com/kubernetes/cloud-provider-gcp.git
+git clone -b providers/v0.21.0 --depth 1 https://github.com/kubernetes/cloud-provider-gcp.git
 cd cloud-provider-gcp
 CGO_ENABLED=0 go build -v -tags "$TAGS" -ldflags "$LDFLAGS" -o=${BASE}/bin/plugins/auth-provider-gcp cmd/auth-provider-gcp/*.go


### PR DESCRIPTION
The kubernetes/cloud-provider-gcp repo changed the name of their v0.21.0
tag to provider/v0.21.0, this commit fixes that

This is the build failure I saw:
```
+ git clone -b v0.21.0 --depth 1 https://github.com/kubernetes/cloud-provider-gcp.git
Cloning into 'cloud-provider-gcp'...
warning: Could not find remote branch v0.21.0 to clone.
fatal: Remote branch v0.21.0 not found in upstream origin
```

I found this while working on [harvester#2011](https://github.com/harvester/harvester/issues/2011).