### PR TITLE
Increase dial timeout to allow for DNS failover

### DIFF
--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -123,9 +123,12 @@ func (r *registry) getTransport(endpointURL *url.URL) http.RoundTripper {
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
 					// By default we wrap the transport in retries, so reduce the
-					// default dial timeout to 5s to avoid 5x 30s of connection
+					// default dial timeout to 16s to avoid 5x 30s of connection
 					// timeouts when doing the "ping" on certain http registries.
-					Timeout:   5 * time.Second,
+					// Note that the DNS failover timeout is 5 seconds; we must keep the dial
+					// timeout above 15 seconds to allow resolution to fail over through up to
+					// 3 backup nameservers.
+					Timeout:   16 * time.Second,
 					KeepAlive: 30 * time.Second,
 				}).DialContext,
 				TLSClientConfig:       tlsConfig,


### PR DESCRIPTION
The Transport config cribbed from https://github.com/google/go-containerregistry/blob/v0.12.1/pkg/v1/remote/options.go#L85-L101 sets a 5 second dial timeout. Unfortunately, the spec for DNS clients requires a 5 second delay before trying secondary nameservers. This meant that if the primary nameserver is unavailable, wharfie would timeout the dial before consulting secondary nameservers.

Raising this to 16 seconds will increase delays when failing over from unavailable upstream registries, but should properly handle DNS server failover.

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>