### PR TITLE
Only apply rewrites to mirror endpoints

### DIFF
--- a/pkg/registries/endpoint.go
+++ b/pkg/registries/endpoint.go
@@ -93,6 +93,12 @@ func (e endpoint) RoundTrip(req *http.Request) (*http.Response, error) {
 	return e.registry.getTransport(req.URL).RoundTrip(req)
 }
 
+// isDefault returns true if this endpoint is the default endpoint for the image -
+// does the registry namespace match the mirror endpoint namespace?
+func (e endpoint) isDefault() bool {
+	return getNamespace(e.ref.Context().RegistryStr()) == getNamespace(e.url.Host)
+}
+
 func getNamespace(host string) string {
 	if host == defaultRegistryHost {
 		return defaultRegistry


### PR DESCRIPTION
* Makes behavior consistent with recent releases of K3s and RKE2
* Fixes https://github.com/rancher/wharfie/issues/25


Test confirms that the rewrites are applied when pulling from a mirror endpoint, but not when pulling from the default endpoint:
```
=== RUN   TestImage/Pull_busybox_without_rewrite_on_default_endpoint
time="2024-10-01T21:40:50Z" level=info msg="generated self-signed CA certificate CN=dynamiclistener-ca@1727818850,O=dynamiclistener-org: notBefore=2024-10-01 21:40:50.005892519 +0000 UTC notAfter=2034-09-29 21:40:50.005892519 +0000 UTC"
time="2024-10-01T21:40:50Z" level=info msg="certificate CN=127-0-0-1.sslip.io,O=TestImage/Pull_busybox_without_rewrite_on_default_endpoint signed by CN=dynamiclistener-ca@1727818850,O=dynamiclistener-org: notBefore=2024-10-01 21:40:50 +0000 UTC notAfter=2025-10-01 21:40:50 +0000 UTC"
    endpoint_test.go:50: INFO: TestImage/Pull_busybox_without_rewrite_on_default_endpoint registry 127-0-0-1.sslip.io at https://127-0-0-1.sslip.io, auth 127-0-0-1.sslip.io at https://127-0-0-1.sslip.io, scheme "Basic"
=== RUN   TestImage/Pull_busybox_without_rewrite_on_default_endpoint/library/busybox:latest
time="2024-10-01T21:40:50Z" level=debug msg="Trying endpoint https://127-0-0-1.sslip.io:443/v2"
time="2024-10-01T21:40:50Z" level=debug msg="Registry endpoint URL modified: https://127-0-0-1.sslip.io/v2/ => https://127-0-0-1.sslip.io:443/v2/?ns=127-0-0-1.sslip.io"
time="2024-10-01T21:40:50Z" level=debug msg="Registry endpoint URL modified: https://127-0-0-1.sslip.io/v2/bogus-image-prefix/busybox/manifests/latest => https://127-0-0-1.sslip.io:443/v2/bogus-image-prefix/busybox/manifests/latest?ns=127-0-0-1.sslip.io"
time="2024-10-01T21:40:50Z" level=warning msg="Failed to get image from endpoint: GET https://127-0-0-1.sslip.io:443/v2/bogus-image-prefix/busybox/manifests/latest?ns=REDACTED: unexpected status code 404 Not Found"
time="2024-10-01T21:40:50Z" level=debug msg="Trying endpoint https://127-0-0-1.sslip.io/v2"
    endpoint_test.go:103: OK: 127-0-0-1.sslip.io/library/busybox:latest
```
