### PR TITLE
Make the build consistent across archs for Go to correctly report the package path inside the binary

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -6,7 +6,7 @@ cd $(dirname $0)/..
 
 TAGS="netcgo osusergo static_build"
 LDFLAGS="-w -s -X main.version=$VERSION"
-CGO_ENABLED=0 go build -v -tags "$TAGS" -ldflags "$LDFLAGS" -o bin/wharfie-amd64 ./main.go
+CGO_ENABLED=0 go build -v -tags "$TAGS" -ldflags "$LDFLAGS" -o bin/wharfie-amd64
 
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -tags "$TAGS" -ldflags "$LDFLAGS" -o bin/wharfie-arm64 


### PR DESCRIPTION
The amd64 build process is passing directly the `./main.go` file for the build. According to https://github.com/golang/go/issues/36793, this results in Go not properly identifying the package and module path and then marking the compiled binary as `command-line-arguments`. This doesn't happen with the arm64 build.

The resulting effect is the following:

[**wharfie-amd64**](https://github.com/rancher/wharfie/releases/download/v0.6.7/wharfie-amd64)

```
go version -m wharfie-amd64 | head -n 3
wharfie-amd64: go1.22.7
	path	command-line-arguments
	dep	github.com/NYTimes/gziphandler	v1.1.1	h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
```

[**wharfie-arm64**](https://github.com/rancher/wharfie/releases/download/v0.6.7/wharfie-arm64)

```
go version -m wharfie-arm64 | head -n 3
wharfie-arm64: go1.22.7
	path	github.com/rancher/wharfie
	mod	github.com/rancher/wharfie	(devel)
```

The `wharfie-amd64` binary lacks the `mod github.com/rancher/wharfie` identification. Although this is a minor thing and that doesn't affect the binary itself, it actually blocks security scanners, for example Trivy, from correctly matching the binary (and its path/module origin) with a VEX entry, as an example, see this [entry](https://github.com/rancher/vexhub/blob/33cbe98c1923af66a9b83aae383a513b3b7e69e1/pkg/golang/github.com/rancher/wharfie/scan.openvex.json#L562-L579).

This was identified internally when a false-positive vulnerability that was supposed to be suppressed was still being reported in the scanning reports.